### PR TITLE
Use sentinel list to guard RequestHandlerContext disposal

### DIFF
--- a/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/AI/Agents/ConversationHandler.cs
@@ -386,12 +386,13 @@ internal class ConversationHandler(ServerStore server, DocumentDatabase database
             return;
 
         var multiGetHandler = new MultiGetHandler();
-        multiGetHandler.Init(new RequestHandlerContext
+        using var multiGetContext = new RequestHandlerContext
         {
             Database = database,
             RavenServer = server.Server,
             HttpContext = new DefaultHttpContext()
-        });
+        };
+        multiGetHandler.Init(multiGetContext);
 
         using (var reqsBlittable = context.ReadObject(new DynamicJsonValue { ["Requests"] = reqs }, "ai-agent/multi-query"))
         using (var handler = new MultiGetHandlerProcessorForPost(multiGetHandler))

--- a/src/Raven.Server/Documents/Handlers/Processors/MultiGet/AbstractMultiGetHandlerProcessorForPost.cs
+++ b/src/Raven.Server/Documents/Handlers/Processors/MultiGet/AbstractMultiGetHandlerProcessorForPost.cs
@@ -171,7 +171,7 @@ internal abstract class AbstractMultiGetHandlerProcessorForPost<TRequestHandler,
             if (RequestHandler.Server.Configuration.Security.AuthenticationEnabled == false
                 || (await RequestHandler.Server.Router.TryAuthorizeAsync(routeInformation, httpContext, RequestHandler.DatabaseName)).Authorized)
             {
-                var handlerContext = new RequestHandlerContext
+                using var handlerContext = new RequestHandlerContext
                 {
                     RavenServer = RequestHandler.Server,
                     RouteMatch = localMatch,

--- a/src/Raven.Server/RavenServerStartup.cs
+++ b/src/Raven.Server/RavenServerStartup.cs
@@ -166,7 +166,7 @@ namespace Raven.Server
 
         private async Task RequestHandler(HttpContext context)
         {
-            var requestHandlerContext = new RequestHandlerContext
+            using var requestHandlerContext = new RequestHandlerContext
             {
                 HttpContext = context
             };

--- a/src/Raven.Server/ServerWide/LocalEndpointClient.cs
+++ b/src/Raven.Server/ServerWide/LocalEndpointClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -29,10 +29,10 @@ namespace Raven.Server.ServerWide
             _server = server;
         }
 
-        public async Task<HttpResponse> InvokeAsync(RouteInformation route, 
+        public async Task<HttpResponse> InvokeAsync(RouteInformation route,
             Dictionary<string, StringValues> parameters = null, CancellationToken cancellationToken = default)
         {
-            var requestContext = new RequestHandlerContext
+            using var requestContext = new RequestHandlerContext
             {
                 HttpContext = new LocalInvocationCustomHttpContext(route.Method, route.Path),
                 RavenServer = _server,

--- a/src/Raven.Server/Web/RequestHandlerContext.cs
+++ b/src/Raven.Server/Web/RequestHandlerContext.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Raven.Server.Documents;
 using Raven.Server.Documents.Sharding;
@@ -6,8 +8,11 @@ using Raven.Server.Utils;
 
 namespace Raven.Server.Web
 {
-    public sealed class RequestHandlerContext
+    public sealed class RequestHandlerContext : IDisposable
     {
+        private static readonly List<IDisposable> DisposedSentinel = new();
+        private List<IDisposable> _disposables;
+
         public HttpContext HttpContext;
         public RavenServer RavenServer;
         public RouteMatch RouteMatch;
@@ -18,5 +23,56 @@ namespace Raven.Server.Web
         public string DatabaseName => Database?.Name ?? DatabaseContext?.DatabaseName;
         public MetricCounters DatabaseMetrics => Database?.Metrics ?? DatabaseContext?.Metrics;
         public string ClusterTransactionId => Database?.ClusterTransactionId ?? DatabaseContext?.DatabaseRecord.GetClusterTransactionId();
+
+        public IDisposable Register(IDisposable disposable)
+        {
+            if (disposable == null)
+                return null;
+
+            if (ReferenceEquals(_disposables, DisposedSentinel))
+                throw new ObjectDisposedException(nameof(RequestHandlerContext));
+
+            var disposables = _disposables;
+            if (disposables == null)
+            {
+                disposables = new List<IDisposable>();
+                _disposables = disposables;
+            }
+
+            disposables.Add(disposable);
+
+            return disposable;
+        }
+
+        public void Dispose()
+        {
+            var disposables = _disposables;
+            if (ReferenceEquals(disposables, DisposedSentinel))
+                return;
+
+            _disposables = DisposedSentinel;
+
+            if (disposables == null)
+                return;
+
+            List<Exception> exceptions = null;
+            for (var i = disposables.Count - 1; i >= 0; i--)
+            {
+                try
+                {
+                    disposables[i]?.Dispose();
+                }
+                catch (Exception e)
+                {
+                    exceptions ??= new List<Exception>();
+                    exceptions.Add(e);
+                }
+            }
+
+            disposables.Clear();
+
+            if (exceptions != null)
+                throw new AggregateException("Failed to dispose request handler context resources.", exceptions);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- replace the disposal state flag in `RequestHandlerContext` with a sentinel disposable list
- ensure registrations throw once the context has been disposed while preserving LIFO cleanup semantics

## Testing
- dotnet build RavenDB.sln *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5076fbe5c8331a429c7d97bb65462