### PR TITLE
Implement Azure Service Bus queue transport

### DIFF
--- a/docs/AzureServiceBusIntegrationPlan.md
+++ b/docs/AzureServiceBusIntegrationPlan.md
@@ -1,0 +1,76 @@
+# Azure Service Bus Queue Integration Plan
+
+## Goals
+- Support Azure Service Bus as both an **outgoing transport** (Queue ETL) and an **incoming transport** (Queue Sink) within RavenDB.
+- Keep the user experience aligned with existing queue brokers (Kafka, RabbitMQ, Amazon SQS, Azure Queue Storage).
+- Ensure that configuration, monitoring, scripting, and diagnostics work consistently across the new transport.
+
+## High-Level Architecture
+1. **Client API surface**
+   - Extend `QueueBrokerType` with `AzureServiceBus` (done).
+   - Introduce `AzureServiceBusConnectionSettings` describing namespace, entity path (queue or topic/subscription), and authentication (connection string, SAS, or Entra ID managed identity).
+   - Update `QueueConnectionString` serialization/deserialization to persist the new settings and validate mutually exclusive authentication modes.
+   - Extend `QueueEtlConfiguration` and `QueueSinkConfiguration` DTOs to accept Azure Service Bus specific options (entity declarations, prefetch, batching, dead-letter handling flags).
+
+2. **Server-side ETL (Outgoing)**
+   - Create `AzureServiceBusEtl` that derives from `QueueEtl<QueueItem>`.
+   - Implement an `AzureServiceBusQueue` writer responsible for batching CloudEvent messages and publishing them using the `Azure.Messaging.ServiceBus` SDK.
+   - Provide queue/topic declaration helpers honoring the `SkipAutomaticQueueDeclaration` flag and configurable entity creation policies.
+   - Ensure checkpointing reuses existing queue ETL storage (no schema changes expected) but extend state to capture sequence numbers and session ids if required.
+
+3. **Server-side Queue Sink (Incoming)**
+   - Implement `AzureServiceBusQueueSink` with a `ServiceBusProcessor` (queue) and `ServiceBusSessionProcessor` (topic/subscription) based consumer.
+   - Support concurrency controls (max concurrent calls, session lock renewal) and graceful shutdown semantics consistent with other sinks.
+   - Map Service Bus message metadata to `QueueItemAttributes` (message id, session id, correlation id, delivery count, dead letter reason).
+   - Integrate poison-message handling by routing repeatedly failing messages to the Service Bus dead-letter queue.
+
+4. **Shared infrastructure**
+   - Add connection string bootstrap validation for Service Bus namespaces and credentials.
+   - Extend testing harnesses and queue simulators to understand the new broker type.
+   - Update dashboard counters, ongoing tasks UI, and debugging tools to surface Azure Service Bus ETL/Sink counts and stats.
+
+## Implementation Steps
+1. **Model Layer**
+   - [x] Extend `QueueBrokerType` with `AzureServiceBus` (part of this change).
+   - [ ] Add `AzureServiceBusConnectionSettings` and hook it into `QueueConnectionString` (validation, equality, serialization).
+   - [ ] Introduce ETL/Sink configuration knobs (e.g., entity type, max batch size, prefetch count, auto-declare entity, dead-letter options).
+
+2. **Server ETL Pipeline**
+   - [ ] Implement `AzureServiceBusEtl` class along with publisher abstractions.
+   - [ ] Extend `QueueEtlConfiguration.UsingEncryptedCommunicationChannel` and connection bootstrap logic to compute encryption status using Service Bus endpoints.
+   - [ ] Wire the ETL loader to instantiate the new process and track metrics/state.
+
+3. **Queue Sink Pipeline**
+   - [ ] Implement `AzureServiceBusQueueSink` and underlying consumer that maps Service Bus messages into `QueueItem` instances.
+   - [ ] Integrate acknowledgement, retry, and dead-letter handling with `QueueSinkProcess` contracts.
+   - [ ] Extend sink loader metadata and stats collectors.
+
+4. **Studio & Tooling**
+   - [ ] Update Studio models/commands to expose Azure Service Bus as a selectable broker type with connection string editors.
+   - [ ] Enhance dashboard widgets and ongoing task pages to show counts and state for the new transport.
+   - [ ] Provide documentation snippets and sample scripts covering both queue and topic/subscription scenarios.
+
+## Testing Strategy
+- **Unit / Fast Tests**
+  - Validate configuration and factory behavior (see `AzureServiceBusConfigurationTests` added with this plan) to ensure unsupported scenarios fail with explicit messages until the full implementation arrives.
+  - Add serialization round-trip tests for `AzureServiceBusConnectionSettings` once introduced.
+
+- **Integration Tests (Slow Tests)**
+  - Queue ETL:
+    - Verify message publishing to queues and topics, including batched writes and CloudEvent metadata mapping.
+    - Confirm checkpoint persistence and resume after restarts.
+    - Test automatic entity creation toggles and failure reporting.
+  - Queue Sink:
+    - Validate message consumption for queues and topic subscriptions (with and without sessions).
+    - Ensure message retries, dead-letter routing, and fallback intervals behave as expected.
+    - Exercise script error handling and document deletion settings.
+
+- **Stress / Reliability**
+  - Long-running soak tests covering session-enabled subscriptions and high-throughput queues.
+  - Fault-injection scenarios: transient network failures, SAS token rotation, entity removal.
+
+## Deliverables Snapshot
+- Enumerations and configuration models updated to include Azure Service Bus.
+- Placeholder fast tests guaranteeing that unsupported usage surfaces actionable errors.
+- Comprehensive plan for extending ETL and Queue Sink stacks, including server, client, and Studio work.
+- Explicit testing roadmap to be executed alongside the implementation.

--- a/src/Raven.Client/Documents/Operations/ETL/Queue/AzureServiceBusConnectionSettings.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Queue/AzureServiceBusConnectionSettings.cs
@@ -1,0 +1,239 @@
+using System;
+using Raven.Client.Documents.Operations.ETL.SQL;
+using Sparrow.Json.Parsing;
+
+namespace Raven.Client.Documents.Operations.ETL.Queue;
+
+public sealed class AzureServiceBusConnectionSettings
+{
+    public string ConnectionString { get; set; }
+
+    public AzureServiceBusEntraId EntraId { get; set; }
+
+    public AzureServiceBusPasswordless Passwordless { get; set; }
+
+    public bool IsValidConnection()
+    {
+        if (IsOnlyOneConnectionProvided() == false)
+            return false;
+
+        if (EntraId != null && EntraId.IsValid() == false)
+            return false;
+
+        if (Passwordless != null && Passwordless.IsValid() == false)
+            return false;
+
+        if (ConnectionString != null)
+        {
+            try
+            {
+                _ = GetEndpoint();
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private bool IsOnlyOneConnectionProvided()
+    {
+        int count = 0;
+
+        if (!string.IsNullOrWhiteSpace(ConnectionString))
+            count++;
+
+        if (EntraId != null)
+            count++;
+
+        if (Passwordless != null)
+            count++;
+
+        return count == 1;
+    }
+
+    public string GetEndpoint()
+    {
+        if (!string.IsNullOrWhiteSpace(ConnectionString))
+        {
+            var endpoint = SqlConnectionStringParser.GetConnectionStringValue(ConnectionString, ["Endpoint"]);
+            if (string.IsNullOrWhiteSpace(endpoint))
+                throw new ArgumentException("Endpoint not found in the connection string", nameof(ConnectionString));
+
+            return EnsureTrailingSlash(endpoint);
+        }
+
+        var fullyQualifiedNamespace = GetFullyQualifiedNamespace();
+        return string.IsNullOrWhiteSpace(fullyQualifiedNamespace)
+            ? null
+            : $"sb://{fullyQualifiedNamespace}/";
+    }
+
+    public string GetFullyQualifiedNamespace()
+    {
+        if (!string.IsNullOrWhiteSpace(ConnectionString))
+        {
+            var endpoint = SqlConnectionStringParser.GetConnectionStringValue(ConnectionString, ["Endpoint"]);
+            if (string.IsNullOrWhiteSpace(endpoint))
+                throw new ArgumentException("Endpoint not found in the connection string", nameof(ConnectionString));
+
+            var uri = new Uri(endpoint);
+            return uri.Host;
+        }
+
+        if (EntraId != null)
+            return EntraId.FullyQualifiedNamespace;
+
+        if (Passwordless != null)
+            return Passwordless.FullyQualifiedNamespace;
+
+        return null;
+    }
+
+    public DynamicJsonValue ToJson()
+    {
+        return new DynamicJsonValue
+        {
+            [nameof(ConnectionString)] = ConnectionString,
+            [nameof(EntraId)] = EntraId?.ToJson(),
+            [nameof(Passwordless)] = Passwordless?.ToJson()
+        };
+    }
+
+    public DynamicJsonValue ToAuditJson()
+    {
+        return new DynamicJsonValue
+        {
+            [nameof(EntraId)] = EntraId?.ToAuditJson(),
+            [nameof(Passwordless)] = Passwordless?.ToAuditJson(),
+            ["ConnectionStringDefined"] = string.IsNullOrWhiteSpace(ConnectionString) == false
+        };
+    }
+
+    private static string EnsureTrailingSlash(string endpoint)
+    {
+        if (endpoint.EndsWith("/", StringComparison.Ordinal))
+            return endpoint;
+
+        return endpoint + "/";
+    }
+
+    private bool Equals(AzureServiceBusConnectionSettings other)
+    {
+        return string.Equals(ConnectionString, other.ConnectionString, StringComparison.Ordinal) &&
+               Equals(EntraId, other.EntraId) &&
+               Equals(Passwordless, other.Passwordless);
+    }
+
+    public override bool Equals(object obj)
+    {
+        return ReferenceEquals(this, obj) || obj is AzureServiceBusConnectionSettings other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(ConnectionString, EntraId, Passwordless);
+    }
+}
+
+public sealed class AzureServiceBusEntraId
+{
+    public string FullyQualifiedNamespace { get; set; }
+
+    public string TenantId { get; set; }
+
+    public string ClientId { get; set; }
+
+    public string ClientSecret { get; set; }
+
+    public bool IsValid()
+    {
+        return string.IsNullOrWhiteSpace(FullyQualifiedNamespace) == false &&
+               string.IsNullOrWhiteSpace(TenantId) == false &&
+               string.IsNullOrWhiteSpace(ClientId) == false &&
+               string.IsNullOrWhiteSpace(ClientSecret) == false;
+    }
+
+    internal DynamicJsonValue ToJson()
+    {
+        return new DynamicJsonValue
+        {
+            [nameof(FullyQualifiedNamespace)] = FullyQualifiedNamespace,
+            [nameof(TenantId)] = TenantId,
+            [nameof(ClientId)] = ClientId,
+            [nameof(ClientSecret)] = ClientSecret
+        };
+    }
+
+    internal DynamicJsonValue ToAuditJson()
+    {
+        return new DynamicJsonValue
+        {
+            [nameof(FullyQualifiedNamespace)] = FullyQualifiedNamespace,
+            [nameof(TenantId)] = TenantId,
+            [nameof(ClientId)] = ClientId,
+            ["ClientSecretDefined"] = string.IsNullOrWhiteSpace(ClientSecret) == false
+        };
+    }
+
+    private bool Equals(AzureServiceBusEntraId other)
+    {
+        return string.Equals(FullyQualifiedNamespace, other.FullyQualifiedNamespace, StringComparison.Ordinal) &&
+               string.Equals(TenantId, other.TenantId, StringComparison.Ordinal) &&
+               string.Equals(ClientId, other.ClientId, StringComparison.Ordinal) &&
+               string.Equals(ClientSecret, other.ClientSecret, StringComparison.Ordinal);
+    }
+
+    public override bool Equals(object obj)
+    {
+        return ReferenceEquals(this, obj) || obj is AzureServiceBusEntraId other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(FullyQualifiedNamespace, TenantId, ClientId, ClientSecret);
+    }
+}
+
+public sealed class AzureServiceBusPasswordless
+{
+    public string FullyQualifiedNamespace { get; set; }
+
+    public bool IsValid()
+    {
+        return string.IsNullOrWhiteSpace(FullyQualifiedNamespace) == false;
+    }
+
+    internal DynamicJsonValue ToJson()
+    {
+        return new DynamicJsonValue
+        {
+            [nameof(FullyQualifiedNamespace)] = FullyQualifiedNamespace
+        };
+    }
+
+    internal DynamicJsonValue ToAuditJson()
+    {
+        return new DynamicJsonValue
+        {
+            [nameof(FullyQualifiedNamespace)] = FullyQualifiedNamespace
+        };
+    }
+
+    private bool Equals(AzureServiceBusPasswordless other)
+    {
+        return string.Equals(FullyQualifiedNamespace, other.FullyQualifiedNamespace, StringComparison.Ordinal);
+    }
+
+    public override bool Equals(object obj)
+    {
+        return ReferenceEquals(this, obj) || obj is AzureServiceBusPasswordless other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return FullyQualifiedNamespace != null ? FullyQualifiedNamespace.GetHashCode(StringComparison.Ordinal) : 0;
+    }
+}

--- a/src/Raven.Client/Documents/Operations/ETL/Queue/QueueBrokerType.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Queue/QueueBrokerType.cs
@@ -6,5 +6,6 @@ public enum QueueBrokerType
     Kafka,
     RabbitMq,
     AzureQueueStorage,
-    AmazonSqs
+    AmazonSqs,
+    AzureServiceBus
 }

--- a/src/Raven.Client/Documents/Operations/ETL/Queue/QueueConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Queue/QueueConnectionString.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Raven.Client.Documents.Operations.ConnectionStrings;
 using Sparrow.Json.Parsing;
@@ -14,8 +14,10 @@ public sealed class QueueConnectionString : ConnectionString
     public RabbitMqConnectionSettings RabbitMqConnectionSettings { get; set; }
 
     public AzureQueueStorageConnectionSettings AzureQueueStorageConnectionSettings { get; set; }
-    
+
     public AmazonSqsConnectionSettings AmazonSqsConnectionSettings { get; set; }
+
+    public AzureServiceBusConnectionSettings AzureServiceBusConnectionSettings { get; set; }
     
     public override ConnectionStringType Type => ConnectionStringType.Queue;
 
@@ -47,6 +49,13 @@ public sealed class QueueConnectionString : ConnectionString
                     errors.Add($"{nameof(AmazonSqsConnectionSettings)} has no valid setting.");
                 }
                 break;
+            case QueueBrokerType.AzureServiceBus:
+                if (AzureServiceBusConnectionSettings == null ||
+                    AzureServiceBusConnectionSettings.IsValidConnection() == false)
+                {
+                    errors.Add($"{nameof(AzureServiceBusConnectionSettings)} has no valid setting.");
+                }
+                break;
             default:
                 throw new NotSupportedException($"'{BrokerType}' broker is not supported");
         }
@@ -74,6 +83,9 @@ public sealed class QueueConnectionString : ConnectionString
             case QueueBrokerType.AmazonSqs:
                 url = AmazonSqsConnectionSettings.GetQueueUrl();
                 break;
+            case QueueBrokerType.AzureServiceBus:
+                url = AzureServiceBusConnectionSettings.GetEndpoint();
+                break;
             default:
                 throw new NotSupportedException($"'{BrokerType}' broker is not supported");
         }
@@ -90,6 +102,7 @@ public sealed class QueueConnectionString : ConnectionString
         json[nameof(RabbitMqConnectionSettings)] = RabbitMqConnectionSettings?.ToJson();
         json[nameof(AzureQueueStorageConnectionSettings)] = AzureQueueStorageConnectionSettings?.ToJson();
         json[nameof(AmazonSqsConnectionSettings)] = AmazonSqsConnectionSettings?.ToJson();
+        json[nameof(AzureServiceBusConnectionSettings)] = AzureServiceBusConnectionSettings?.ToJson();
 
         return json;
     }
@@ -101,6 +114,7 @@ public sealed class QueueConnectionString : ConnectionString
         json[nameof(BrokerType)] = BrokerType;
         json[nameof(KafkaConnectionSettings)] = KafkaConnectionSettings?.ToAuditJson();
         json[nameof(RabbitMqConnectionSettings)] = RabbitMqConnectionSettings?.ToAuditJson();
+        json[nameof(AzureServiceBusConnectionSettings)] = AzureServiceBusConnectionSettings?.ToAuditJson();
 
         return json;
     }
@@ -153,6 +167,17 @@ public sealed class QueueConnectionString : ConnectionString
                         return false;
 
                     return AmazonSqsConnectionSettings.Equals(queueConnectionString.AmazonSqsConnectionSettings);
+
+                case QueueBrokerType.AzureServiceBus:
+                    if (AzureServiceBusConnectionSettings == null &&
+                        queueConnectionString.AzureServiceBusConnectionSettings == null)
+                        return true;
+
+                    if (AzureServiceBusConnectionSettings == null ||
+                        queueConnectionString.AzureServiceBusConnectionSettings == null)
+                        return false;
+
+                    return AzureServiceBusConnectionSettings.Equals(queueConnectionString.AzureServiceBusConnectionSettings);
 
                 default:
                     throw new NotSupportedException($"'{BrokerType}' broker is not supported");

--- a/src/Raven.Client/Documents/Operations/ETL/Queue/QueueEtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/Queue/QueueEtlConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Sparrow.Json.Parsing;
@@ -52,12 +52,17 @@ namespace Raven.Client.Documents.Operations.ETL.Queue
                 case QueueBrokerType.AzureQueueStorage:
                     return Connection.AzureQueueStorageConnectionSettings.GetStorageUrl()
                         .StartsWith("https", StringComparison.OrdinalIgnoreCase);
-                case QueueBrokerType.AmazonSqs:
-                    return Connection.AmazonSqsConnectionSettings.GetQueueUrl()
-                        .StartsWith("https", StringComparison.OrdinalIgnoreCase);
-                default:
-                    throw new NotSupportedException($"Unknown broker type: {BrokerType}");
-            }
+            case QueueBrokerType.AmazonSqs:
+                return Connection.AmazonSqsConnectionSettings.GetQueueUrl()
+                    .StartsWith("https", StringComparison.OrdinalIgnoreCase);
+            case QueueBrokerType.AzureServiceBus:
+                var endpoint = Connection.AzureServiceBusConnectionSettings.GetEndpoint();
+                return endpoint != null &&
+                       (endpoint.StartsWith("sb://", StringComparison.OrdinalIgnoreCase) ||
+                        endpoint.StartsWith("https://", StringComparison.OrdinalIgnoreCase));
+            default:
+                throw new NotSupportedException($"Unknown broker type: {BrokerType}");
+        }
 
             return false;
         }

--- a/src/Raven.Server/Documents/ETL/Handlers/Processors/EtlHandlerProcessorForProgress.cs
+++ b/src/Raven.Server/Documents/ETL/Handlers/Processors/EtlHandlerProcessorForProgress.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Raven.Client.Documents.Operations.ETL.Queue;

--- a/src/Raven.Server/Documents/ETL/Providers/Queue/AzureServiceBus/AzureServiceBusDocumentTransformer.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Queue/AzureServiceBus/AzureServiceBusDocumentTransformer.cs
@@ -1,0 +1,50 @@
+using Jint.Runtime.Interop;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.ETL.Queue;
+using Raven.Server.Documents.Patch;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Documents.ETL.Providers.Queue.AzureServiceBus;
+
+public sealed class AzureServiceBusDocumentTransformer<T> : QueueDocumentTransformer<T, AzureServiceBusItem>
+    where T : QueueItem
+{
+    public AzureServiceBusDocumentTransformer(Transformation transformation, DocumentDatabase database,
+        DocumentsOperationContext context, QueueEtlConfiguration config) : base(transformation, database, context, config)
+    {
+    }
+
+    protected override void LoadToFunction(string queueName, ScriptRunnerResult document)
+    {
+        LoadToFunction(queueName, document, null);
+    }
+
+    protected override void LoadToFunction(string queueName, ScriptRunnerResult document, CloudEventAttributes attributes)
+    {
+        if (queueName == null)
+            ThrowLoadParameterIsMandatory(nameof(queueName));
+
+        var result = document.TranslateToObject(Context);
+
+        var queue = GetOrAdd(queueName);
+
+        queue.Items.Add(new AzureServiceBusItem(Current) { TransformationResult = result, Attributes = attributes });
+    }
+
+    public override void Initialize(bool debugMode)
+    {
+        base.Initialize(debugMode);
+
+        DocumentScript.ScriptEngine.SetValue(Transformation.LoadTo,
+            new ClrFunction(DocumentScript.ScriptEngine, Transformation.LoadTo,
+                LoadToFunctionTranslatorWithAttributes));
+
+        foreach (var queueName in LoadToDestinations)
+        {
+            var name = Transformation.LoadTo + queueName;
+
+            DocumentScript.ScriptEngine.SetValue(name, new ClrFunction(DocumentScript.ScriptEngine, name,
+                (self, args) => LoadToFunctionTranslatorWithAttributes(queueName, args)));
+        }
+    }
+}

--- a/src/Raven.Server/Documents/ETL/Providers/Queue/AzureServiceBus/AzureServiceBusEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Queue/AzureServiceBus/AzureServiceBusEtl.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Azure;
+using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
+using Raven.Client.Documents.Operations.ETL;
+using Raven.Client.Documents.Operations.ETL.Queue;
+using Raven.Server.Documents.ETL.Stats;
+using Raven.Server.Documents.ETL.Providers.Queue;
+using Raven.Server.Exceptions.ETL.QueueEtl;
+using Raven.Server.ServerWide;
+using Raven.Server.ServerWide.Context;
+
+namespace Raven.Server.Documents.ETL.Providers.Queue.AzureServiceBus;
+
+public sealed class AzureServiceBusEtl : QueueEtl<AzureServiceBusItem>
+{
+    private readonly Dictionary<string, ServiceBusSender> _senders = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<string> _declaredEntities = new(StringComparer.OrdinalIgnoreCase);
+
+    private ServiceBusClient _client;
+    private ServiceBusAdministrationClient _administrationClient;
+
+    public AzureServiceBusEtl(Transformation transformation, QueueEtlConfiguration configuration,
+        DocumentDatabase database, ServerStore serverStore) : base(transformation, configuration, database, serverStore)
+    {
+    }
+
+    protected override
+        EtlTransformer<QueueItem, QueueWithItems<AzureServiceBusItem>, EtlStatsScope, EtlPerformanceOperation>
+        GetTransformer(DocumentsOperationContext context, EtlStatsScope stats)
+    {
+        return new AzureServiceBusDocumentTransformer<AzureServiceBusItem>(Transformation, Database, context,
+            Configuration);
+    }
+
+    protected override int PublishMessages(List<QueueWithItems<AzureServiceBusItem>> itemsPerQueue,
+        BlittableJsonEventBinaryFormatter formatter, out List<string> idsToDelete)
+    {
+        if (itemsPerQueue.Count == 0)
+        {
+            idsToDelete = null;
+            return 0;
+        }
+
+        EnsureClients();
+
+        idsToDelete = new List<string>();
+        var count = 0;
+
+        foreach (QueueWithItems<AzureServiceBusItem> queue in itemsPerQueue)
+        {
+            var entityName = queue.Name;
+
+            if (Configuration.SkipAutomaticQueueDeclaration == false)
+                EnsureEntityExists(entityName);
+
+            var sender = GetOrCreateSender(entityName);
+
+            foreach (AzureServiceBusItem queueItem in queue.Items)
+            {
+                CancellationToken.ThrowIfCancellationRequested();
+
+                var cloudEvent = CreateCloudEvent(queueItem);
+                var body = formatter.EncodeBinaryModeEventData(cloudEvent);
+
+                var message = new ServiceBusMessage(new BinaryData(body))
+                {
+                    ContentType = cloudEvent.DataContentType ?? "application/json",
+                    Subject = cloudEvent.Subject,
+                    MessageId = cloudEvent.Id
+                };
+
+                if (queueItem.Attributes?.PartitionKey != null)
+                    message.PartitionKey = queueItem.Attributes.PartitionKey;
+                else if (queueItem.DocumentId != null)
+                    message.PartitionKey = queueItem.DocumentId;
+
+                if (cloudEvent.Time != null)
+                    message.ApplicationProperties["ce-time"] = cloudEvent.Time.Value.UtcDateTime;
+
+                if (cloudEvent.Source != null)
+                    message.ApplicationProperties["ce-source"] = cloudEvent.Source.ToString();
+
+                if (cloudEvent.Type != null)
+                    message.ApplicationProperties["ce-type"] = cloudEvent.Type;
+
+                if (cloudEvent.DataSchema != null)
+                    message.ApplicationProperties["ce-dataschema"] = cloudEvent.DataSchema.ToString();
+
+                message.ApplicationProperties["raven-document-id"] = queueItem.DocumentId;
+                message.ApplicationProperties["raven-change-vector"] = queueItem.ChangeVector;
+
+                try
+                {
+                    sender.SendMessageAsync(message).GetAwaiter().GetResult();
+                    count++;
+
+                    if (queue.DeleteProcessedDocuments)
+                        idsToDelete.Add(queueItem.DocumentId);
+                }
+                catch (ServiceBusException ex)
+                {
+                    throw new QueueLoadException(
+                        $"Failed to deliver message. Azure Service Bus reason: '{ex.Reason}'. Error: '{ex.Message}'", ex);
+                }
+                catch (Exception ex)
+                {
+                    throw new QueueLoadException($"Failed to deliver message, error reason: '{ex.Message}'", ex);
+                }
+            }
+        }
+
+        return count;
+    }
+
+    private void EnsureClients()
+    {
+        if (_client == null)
+            _client = QueueBrokerConnectionHelper.CreateAzureServiceBusClient(
+                Configuration.Connection.AzureServiceBusConnectionSettings);
+
+        if (Configuration.SkipAutomaticQueueDeclaration == false && _administrationClient == null)
+            _administrationClient = QueueBrokerConnectionHelper.CreateAzureServiceBusAdministrationClient(
+                Configuration.Connection.AzureServiceBusConnectionSettings);
+    }
+
+    private void EnsureEntityExists(string entityName)
+    {
+        if (_administrationClient == null)
+            return;
+
+        if (_declaredEntities.Contains(entityName))
+            return;
+
+        try
+        {
+            if (_administrationClient.QueueExistsAsync(entityName).GetAwaiter().GetResult() == false)
+                _administrationClient.CreateQueueAsync(entityName).GetAwaiter().GetResult();
+
+            _declaredEntities.Add(entityName);
+        }
+        catch (ServiceBusException ex)
+        {
+            throw new QueueLoadException(
+                $"Failed to ensure queue '{entityName}' exists. Azure Service Bus reason: '{ex.Reason}'. Error: '{ex.Message}'",
+                ex);
+        }
+        catch (Exception ex)
+        {
+            throw new QueueLoadException($"Failed to ensure queue '{entityName}' exists, error reason: '{ex.Message}'", ex);
+        }
+    }
+
+    private ServiceBusSender GetOrCreateSender(string entityName)
+    {
+        if (_senders.TryGetValue(entityName, out var sender))
+            return sender;
+
+        sender = _client.CreateSender(entityName);
+        _senders[entityName] = sender;
+        return sender;
+    }
+
+    protected override void OnProcessStopped()
+    {
+        foreach (ServiceBusSender sender in _senders.Values)
+        {
+            try
+            {
+                sender.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
+            catch
+            {
+                // ignore disposal errors
+            }
+        }
+
+        _senders.Clear();
+        _declaredEntities.Clear();
+
+        if (_client != null)
+        {
+            try
+            {
+                _client.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
+            catch
+            {
+                // ignore disposal errors
+            }
+
+            _client = null;
+        }
+
+        if (_administrationClient != null)
+        {
+            try
+            {
+                (_administrationClient as IAsyncDisposable)?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
+            catch
+            {
+                // ignore disposal errors
+            }
+
+            _administrationClient = null;
+        }
+    }
+}

--- a/src/Raven.Server/Documents/ETL/Providers/Queue/AzureServiceBus/AzureServiceBusItem.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Queue/AzureServiceBus/AzureServiceBusItem.cs
@@ -1,0 +1,8 @@
+namespace Raven.Server.Documents.ETL.Providers.Queue.AzureServiceBus;
+
+public sealed class AzureServiceBusItem : QueueItem
+{
+    public AzureServiceBusItem(QueueItem item) : base(item)
+    {
+    }
+}

--- a/src/Raven.Server/Documents/ETL/Providers/Queue/QueueBrokerConnectionHelper.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Queue/QueueBrokerConnectionHelper.cs
@@ -4,6 +4,8 @@ using System.IO;
 using Amazon;
 using Amazon.SQS;
 using Azure.Identity;
+using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
 using Azure.Storage.Queues;
 using Confluent.Kafka;
 using Org.BouncyCastle.Utilities.IO.Pem;
@@ -149,6 +151,58 @@ public static class QueueBrokerConnectionHelper
         }
 
         return queueServiceClient;
+    }
+
+    public static ServiceBusClient CreateAzureServiceBusClient(
+        AzureServiceBusConnectionSettings connectionSettings)
+    {
+        if (connectionSettings == null)
+            throw new ArgumentNullException(nameof(connectionSettings));
+
+        if (string.IsNullOrWhiteSpace(connectionSettings.ConnectionString) == false)
+            return new ServiceBusClient(connectionSettings.ConnectionString);
+
+        if (connectionSettings.EntraId != null)
+        {
+            var credential = new ClientSecretCredential(connectionSettings.EntraId.TenantId,
+                connectionSettings.EntraId.ClientId, connectionSettings.EntraId.ClientSecret);
+
+            return new ServiceBusClient(connectionSettings.GetFullyQualifiedNamespace(), credential);
+        }
+
+        if (connectionSettings.Passwordless != null)
+        {
+            return new ServiceBusClient(connectionSettings.Passwordless.FullyQualifiedNamespace,
+                new DefaultAzureCredential());
+        }
+
+        throw new InvalidOperationException("No valid Azure Service Bus connection settings were provided.");
+    }
+
+    public static ServiceBusAdministrationClient CreateAzureServiceBusAdministrationClient(
+        AzureServiceBusConnectionSettings connectionSettings)
+    {
+        if (connectionSettings == null)
+            throw new ArgumentNullException(nameof(connectionSettings));
+
+        if (string.IsNullOrWhiteSpace(connectionSettings.ConnectionString) == false)
+            return new ServiceBusAdministrationClient(connectionSettings.ConnectionString);
+
+        if (connectionSettings.EntraId != null)
+        {
+            var credential = new ClientSecretCredential(connectionSettings.EntraId.TenantId,
+                connectionSettings.EntraId.ClientId, connectionSettings.EntraId.ClientSecret);
+
+            return new ServiceBusAdministrationClient(connectionSettings.GetFullyQualifiedNamespace(), credential);
+        }
+
+        if (connectionSettings.Passwordless != null)
+        {
+            return new ServiceBusAdministrationClient(connectionSettings.Passwordless.FullyQualifiedNamespace,
+                new DefaultAzureCredential());
+        }
+
+        throw new InvalidOperationException("No valid Azure Service Bus connection settings were provided.");
     }
 
     public static IAmazonSQS CreateAmazonSqsClient(AmazonSqsConnectionSettings connectionSettings)

--- a/src/Raven.Server/Documents/ETL/Providers/Queue/QueueEtl.cs
+++ b/src/Raven.Server/Documents/ETL/Providers/Queue/QueueEtl.cs
@@ -9,6 +9,7 @@ using Raven.Client.Documents.Operations.ETL.Queue;
 using Raven.Server.Documents.ETL.Metrics;
 using Raven.Server.Documents.ETL.Providers.Queue.AmazonSqs;
 using Raven.Server.Documents.ETL.Providers.Queue.AzureQueueStorage;
+using Raven.Server.Documents.ETL.Providers.Queue.AzureServiceBus;
 using Raven.Server.Documents.ETL.Providers.Queue.Enumerators;
 using Raven.Server.Documents.ETL.Providers.Queue.Kafka;
 using Raven.Server.Documents.ETL.Providers.Queue.RabbitMq;
@@ -51,6 +52,8 @@ public abstract class QueueEtl<T> : EtlProcess<QueueItem, QueueWithItems<T>, Que
                 return new AzureQueueStorageEtl(transformation, configuration, database, serverStore);
             case QueueBrokerType.AmazonSqs:
                 return new AmazonSqsEtl(transformation, configuration, database, serverStore);
+            case QueueBrokerType.AzureServiceBus:
+                return new AzureServiceBusEtl(transformation, configuration, database, serverStore);
             default:
                 throw new NotSupportedException($"Unknown broker type: {configuration.BrokerType}");
         }

--- a/src/Raven.Server/Documents/QueueSink/AzureServiceBusQueueSink.cs
+++ b/src/Raven.Server/Documents/QueueSink/AzureServiceBusQueueSink.cs
@@ -1,0 +1,20 @@
+using Raven.Client.Documents.Operations.QueueSink;
+using Raven.Server.Documents.ETL.Providers.Queue;
+
+namespace Raven.Server.Documents.QueueSink;
+
+public sealed class AzureServiceBusQueueSink : QueueSinkProcess
+{
+    public AzureServiceBusQueueSink(QueueSinkConfiguration configuration, QueueSinkScript script, DocumentDatabase database,
+        string tag) : base(configuration, script, database, tag)
+    {
+    }
+
+    protected override IQueueSinkConsumer CreateConsumer()
+    {
+        var client = QueueBrokerConnectionHelper.CreateAzureServiceBusClient(
+            Configuration.Connection.AzureServiceBusConnectionSettings);
+
+        return new AzureServiceBusSinkConsumer(client, Script.Queues);
+    }
+}

--- a/src/Raven.Server/Documents/QueueSink/AzureServiceBusSinkConsumer.cs
+++ b/src/Raven.Server/Documents/QueueSink/AzureServiceBusSinkConsumer.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Azure.Messaging.ServiceBus;
+
+namespace Raven.Server.Documents.QueueSink;
+
+public sealed class AzureServiceBusSinkConsumer : IQueueSinkConsumer
+{
+    private readonly ServiceBusClient _client;
+    private readonly List<ServiceBusReceiver> _receivers = new();
+    private readonly List<(ServiceBusReceiver Receiver, ServiceBusReceivedMessage Message)> _pending = new();
+    private readonly TimeSpan _defaultWaitTime = TimeSpan.FromSeconds(5);
+
+    public AzureServiceBusSinkConsumer(ServiceBusClient client, IEnumerable<string> queueNames)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+
+        if (queueNames == null)
+            throw new ArgumentNullException(nameof(queueNames));
+
+        foreach (var queue in queueNames)
+        {
+            if (string.IsNullOrWhiteSpace(queue))
+                continue;
+
+            _receivers.Add(_client.CreateReceiver(queue));
+        }
+    }
+
+    public byte[] Consume(CancellationToken cancellationToken)
+    {
+        return ConsumeInternal(null, cancellationToken);
+    }
+
+    public byte[] Consume(TimeSpan timeout)
+    {
+        return ConsumeInternal(timeout, CancellationToken.None);
+    }
+
+    private byte[] ConsumeInternal(TimeSpan? timeout, CancellationToken cancellationToken)
+    {
+        if (_receivers.Count == 0)
+            return null;
+
+        var waitTime = timeout ?? _defaultWaitTime;
+
+        while (true)
+        {
+            foreach (var receiver in _receivers)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                ServiceBusReceivedMessage message;
+                try
+                {
+                    message = receiver.ReceiveMessageAsync(waitTime, cancellationToken).GetAwaiter().GetResult();
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+
+                if (message == null)
+                    continue;
+
+                _pending.Add((receiver, message));
+                return message.Body.ToArray();
+            }
+
+            if (timeout.HasValue)
+                return null;
+        }
+    }
+
+    public void Commit()
+    {
+        foreach (var (receiver, message) in _pending)
+        {
+            receiver.CompleteMessageAsync(message).GetAwaiter().GetResult();
+        }
+
+        _pending.Clear();
+    }
+
+    public void Dispose()
+    {
+        foreach (var (receiver, message) in _pending)
+        {
+            try
+            {
+                receiver.AbandonMessageAsync(message).GetAwaiter().GetResult();
+            }
+            catch
+            {
+                // ignore failures during cleanup
+            }
+        }
+
+        _pending.Clear();
+
+        foreach (var receiver in _receivers)
+        {
+            try
+            {
+                receiver.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
+            catch
+            {
+                // ignore failures during cleanup
+            }
+        }
+
+        try
+        {
+            _client.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
+        catch
+        {
+            // ignore failures during cleanup
+        }
+    }
+}

--- a/src/Raven.Server/Documents/QueueSink/QueueSinkProcess.cs
+++ b/src/Raven.Server/Documents/QueueSink/QueueSinkProcess.cs
@@ -39,8 +39,9 @@ namespace Raven.Server.Documents.QueueSink;
 
 public abstract class QueueSinkProcess : IDisposable, ILowMemoryHandler
 {
-    internal const string KafkaTag = "Kafka Sink"; 
+    internal const string KafkaTag = "Kafka Sink";
     internal const string RabbitMqTag = "RabbitMQ Sink";
+    internal const string AzureServiceBusTag = "Azure Service Bus Sink";
 
     private const int MinBatchSize = 16;
 
@@ -84,6 +85,8 @@ public abstract class QueueSinkProcess : IDisposable, ILowMemoryHandler
                 return new KafkaQueueSink(configuration, script, database, KafkaTag);
             case QueueBrokerType.RabbitMq:
                 return new RabbitMqQueueSink(configuration, script, database, RabbitMqTag);
+            case QueueBrokerType.AzureServiceBus:
+                return new AzureServiceBusQueueSink(configuration, script, database, AzureServiceBusTag);
             default:
                 throw new NotSupportedException($"Unknown broker type: {configuration.BrokerType}");
         }

--- a/src/Raven.Server/Raven.Server.csproj
+++ b/src/Raven.Server/Raven.Server.csproj
@@ -136,6 +136,7 @@
     <PackageReference Include="AWSSDK.S3" />
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" />
     <PackageReference Include="Azure.Storage.Queues" />
     <PackageReference Include="BouncyCastle.Cryptography" />
     <PackageReference Include="CloudNative.CloudEvents.NewtonsoftJson" />

--- a/test/FastTests/Client/Queue/AzureServiceBusConfigurationTests.cs
+++ b/test/FastTests/Client/Queue/AzureServiceBusConfigurationTests.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using Raven.Client.Documents.Operations.ETL.Queue;
+using Xunit;
+
+namespace FastTests.Client.Queue;
+
+public class AzureServiceBusConfigurationTests
+{
+    private const string SampleConnectionString =
+        "Endpoint=sb://contoso.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=dummy=";
+
+    [Fact]
+    public void Validate_should_fail_when_settings_missing()
+    {
+        var connectionString = new QueueConnectionString
+        {
+            Name = "AzureServiceBus",
+            BrokerType = QueueBrokerType.AzureServiceBus
+        };
+
+        var errors = new List<string>();
+
+        var isValid = connectionString.Validate(errors);
+
+        Assert.False(isValid);
+        Assert.Contains("AzureServiceBusConnectionSettings has no valid setting.", errors);
+    }
+
+    [Fact]
+    public void Validate_should_succeed_with_connection_string()
+    {
+        var connectionString = new QueueConnectionString
+        {
+            Name = "AzureServiceBus",
+            BrokerType = QueueBrokerType.AzureServiceBus,
+            AzureServiceBusConnectionSettings = new AzureServiceBusConnectionSettings
+            {
+                ConnectionString = SampleConnectionString
+            }
+        };
+
+        var errors = new List<string>();
+
+        var isValid = connectionString.Validate(errors);
+
+        Assert.True(isValid);
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void GetUrl_should_return_endpoint()
+    {
+        var connectionString = new QueueConnectionString
+        {
+            Name = "AzureServiceBus",
+            BrokerType = QueueBrokerType.AzureServiceBus,
+            AzureServiceBusConnectionSettings = new AzureServiceBusConnectionSettings
+            {
+                ConnectionString = SampleConnectionString
+            }
+        };
+
+        var url = connectionString.GetUrl();
+
+        Assert.Equal("sb://contoso.servicebus.windows.net/", url);
+    }
+
+    [Fact]
+    public void UsingEncryptedCommunicationChannel_should_return_true_for_service_bus()
+    {
+        var connection = new QueueConnectionString
+        {
+            Name = "AzureServiceBus",
+            BrokerType = QueueBrokerType.AzureServiceBus,
+            AzureServiceBusConnectionSettings = new AzureServiceBusConnectionSettings
+            {
+                ConnectionString = SampleConnectionString
+            }
+        };
+
+        var configuration = new QueueEtlConfiguration
+        {
+            Name = "AzureServiceBus",
+            BrokerType = QueueBrokerType.AzureServiceBus
+        };
+
+        configuration.Initialize(connection);
+
+        Assert.True(configuration.UsingEncryptedCommunicationChannel());
+    }
+}


### PR DESCRIPTION
## Summary
- add Azure Service Bus connection settings and validation support to queue connection strings and ETL configuration
- implement Azure Service Bus queue ETL writer, including automatic entity provisioning and message publishing
- wire Azure Service Bus into the queue sink pipeline with a new consumer and extend fast tests for the broker configuration

## Testing
- `dotnet build RavenDB.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e648f2fe588331a55b6ec471f5fa2d