### PR TITLE
Replace IDynamicJsonValueConvertible usage with IDynamicJson

### DIFF
--- a/src/Raven.Client/Documents/Operations/Backups/PeriodicBackupConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/Backups/PeriodicBackupConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using Raven.Client.ServerWide;
 using Sparrow.Json;
@@ -10,7 +10,7 @@ namespace Raven.Client.Documents.Operations.Backups
     /// Defines the configuration for periodic backup tasks.
     /// Supports full and incremental backups with configurable frequencies, retention policies, and mentor node assignments.
     /// </summary>
-    public class PeriodicBackupConfiguration : BackupConfiguration, IDatabaseTask, IDynamicJsonValueConvertible
+    public class PeriodicBackupConfiguration : BackupConfiguration, IDatabaseTask, IDynamicJson
     {
         /// <summary>
         /// The name of the periodic backup task.

--- a/src/Raven.Client/Documents/Operations/ConnectionStrings/ConnectionString.cs
+++ b/src/Raven.Client/Documents/Operations/ConnectionStrings/ConnectionString.cs
@@ -1,11 +1,11 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.ConnectionStrings
 {
-    public abstract class ConnectionString : IDynamicJsonValueConvertible
+    public abstract class ConnectionString : IDynamicJson
     {
         public string Name { get; set; }
 

--- a/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/ETL/EtlConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -10,7 +10,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.ETL
 {
-    public abstract class EtlConfiguration<T> : IDynamicJsonValueConvertible, IDatabaseTask where T : ConnectionString
+    public abstract class EtlConfiguration<T> : IDynamicJson, IDatabaseTask where T : ConnectionString
     {
         private bool _initialized;
 

--- a/src/Raven.Client/Documents/Operations/QueueSink/QueueSinkConfiguration.cs
+++ b/src/Raven.Client/Documents/Operations/QueueSink/QueueSinkConfiguration.cs
@@ -13,7 +13,7 @@ namespace Raven.Client.Documents.Operations.QueueSink;
 /// <summary>
 /// The configuration for a queue sink task, which allows integrating with external queueing systems.
 /// </summary>
-public class QueueSinkConfiguration : IDynamicJsonValueConvertible, IDatabaseTask
+public class QueueSinkConfiguration : IDynamicJson, IDatabaseTask
 {
     private bool _initialized;
 

--- a/src/Raven.Client/Documents/Operations/Replication/ExternalReplicationBase.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/ExternalReplicationBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Raven.Client.Documents.Operations.ETL;
 using Raven.Client.Documents.Replication;
@@ -8,7 +8,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.Replication
 {
-    public abstract class ExternalReplicationBase : ReplicationNode, IDatabaseTask, IDynamicJsonValueConvertible
+    public abstract class ExternalReplicationBase : ReplicationNode, IDatabaseTask, IDynamicJson
     {
         public long TaskId
         {

--- a/src/Raven.Client/Documents/Operations/Replication/IExternalReplication.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/IExternalReplication.cs
@@ -1,9 +1,9 @@
-﻿using System;
+using System;
 using Sparrow.Json;
 
 namespace Raven.Client.Documents.Operations.Replication
 {
-    internal interface IExternalReplication : IDynamicJsonValueConvertible
+    internal interface IExternalReplication : IDynamicJson
     {
         bool Disabled { get; set; }
 

--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicationDefinition.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicationDefinition.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Raven.Client.Documents.Replication.Messages;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -9,7 +9,7 @@ namespace Raven.Client.Documents.Operations.Replication
     /// The definition of a pull replication task.
     /// This defines the settings and behavior for pulling data between replication hubs and sinks.
     /// </summary>
-    public sealed class PullReplicationDefinition : IDynamicJsonValueConvertible
+    public sealed class PullReplicationDefinition : IDynamicJson
     {
         /// <summary>
         /// The delay duration for replication. Data will not be replicated until the specified delay has passed.

--- a/src/Raven.Client/Documents/Operations/Replication/PullReplicatonDefinitionAndCurrentConnections.cs
+++ b/src/Raven.Client/Documents/Operations/Replication/PullReplicatonDefinitionAndCurrentConnections.cs
@@ -6,7 +6,7 @@ using Sparrow.Json.Parsing;
 
 namespace Raven.Client.Documents.Operations.Replication
 {
-    public sealed class PullReplicationDefinitionAndCurrentConnections : IDynamicJsonValueConvertible
+    public sealed class PullReplicationDefinitionAndCurrentConnections : IDynamicJson
     {
         public PullReplicationDefinition Definition { get; set; }
         public List<OngoingTaskPullReplicationAsHub> OngoingTasks { get; set; }

--- a/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
+++ b/src/Raven.Server/Documents/Handlers/Debugging/NodeDebugHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -152,7 +152,7 @@ namespace Raven.Server.Documents.Handlers.Debugging
             }
         }
 
-        public sealed class PingResult : IDynamicJsonValueConvertible
+        public sealed class PingResult : IDynamicJson
         {
             public string Url;
             public SetupAliveInfo SetupAlive;

--- a/src/Raven.Server/NotificationCenter/Notifications/Details/EtlErrorInfo.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Details/EtlErrorInfo.cs
@@ -1,10 +1,10 @@
-﻿using System;
+using System;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Server.NotificationCenter.Notifications.Details
 {
-    public sealed class EtlErrorInfo : IDynamicJsonValueConvertible
+    public sealed class EtlErrorInfo : IDynamicJson
     {
         public string DocumentId { get; set; }
         public DateTime Date { get; set; }

--- a/src/Raven.Server/NotificationCenter/Notifications/Details/HugeDocumentsDetails.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Details/HugeDocumentsDetails.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Linq;
 using Sparrow.Json;
@@ -61,7 +61,7 @@ namespace Raven.Server.NotificationCenter.Notifications.Details
         }
     }
 
-    public struct HugeDocumentInfo : IDynamicJsonValueConvertible
+    public struct HugeDocumentInfo : IDynamicJson
     {
         public long Size;
         public DateTime Date;

--- a/src/Raven.Server/NotificationCenter/Notifications/Details/QueueSinkErrorInfo.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Details/QueueSinkErrorInfo.cs
@@ -1,10 +1,10 @@
-﻿using System;
+using System;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Server.NotificationCenter.Notifications.Details
 {
-    public class QueueSinkErrorInfo : IDynamicJsonValueConvertible
+    public class QueueSinkErrorInfo : IDynamicJson
     {
         public QueueSinkErrorInfo(string error)
         {

--- a/src/Raven.Server/NotificationCenter/Notifications/Details/RequestLatencyDetail.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Details/RequestLatencyDetail.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -65,7 +65,7 @@ namespace Raven.Server.NotificationCenter.Notifications.Details
         }
     }
 
-    public struct RequestLatencyInfo : IDynamicJsonValueConvertible
+    public struct RequestLatencyInfo : IDynamicJson
     {
         public long Duration;
         public DateTime Date;

--- a/src/Raven.Server/NotificationCenter/Notifications/Details/ServerLimitsDetails.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Details/ServerLimitsDetails.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -25,7 +25,7 @@ public class ServerLimitsDetails : INotificationDetails
         return djv;
     }
 
-    public class ServerLimitInfo : IDynamicJsonValueConvertible
+    public class ServerLimitInfo : IDynamicJson
     {
         public long Value { get; set; }
         public long Max { get; set; }

--- a/src/Raven.Server/NotificationCenter/Notifications/Details/SlowIoDetails.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Details/SlowIoDetails.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -27,7 +27,7 @@ namespace Raven.Server.NotificationCenter.Notifications.Details
             return djv;
         }
 
-        public sealed class SlowWriteInfo : IDynamicJsonValueConvertible
+        public sealed class SlowWriteInfo : IDynamicJson
         {
             public string Key => $"{Type}/{Path}";
 

--- a/src/Raven.Server/NotificationCenter/Notifications/Details/SlowSqlStatementInfo.cs
+++ b/src/Raven.Server/NotificationCenter/Notifications/Details/SlowSqlStatementInfo.cs
@@ -1,10 +1,10 @@
-﻿using System;
+using System;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Server.NotificationCenter.Notifications.Details
 {
-    public sealed class SlowSqlStatementInfo : IDynamicJsonValueConvertible
+    public sealed class SlowSqlStatementInfo : IDynamicJson
     {
         public long Duration { get; set; }
         public DateTime Date { get; set; }

--- a/src/Raven.Server/Rachis/LogSummary.cs
+++ b/src/Raven.Server/Rachis/LogSummary.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Sparrow.Json;
 using Sparrow.Json.Parsing;
@@ -6,7 +6,7 @@ using static Raven.Server.Rachis.RachisConsensus;
 
 namespace Raven.Server.Rachis
 {
-    public sealed class LogSummary : IDynamicJsonValueConvertible
+    public sealed class LogSummary : IDynamicJson
     {
         public DateTime? LastCommitedTime { get; set; }
         public DateTime? LastAppendedTime { get; set; }

--- a/src/Raven.Server/Rachis/RachisConsensus.Debug.cs
+++ b/src/Raven.Server/Rachis/RachisConsensus.Debug.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -214,7 +214,7 @@ public abstract partial class RachisConsensus
         }
     }
 
-    public class UnrecoverableClusterError : IDynamicJsonValueConvertible
+    public class UnrecoverableClusterError : IDynamicJson
     {
         public string Id;
         public string Title;
@@ -234,7 +234,7 @@ public abstract partial class RachisConsensus
         }
     }
 
-    public class RachisDebugLogEntry : IDynamicJsonValueConvertible
+    public class RachisDebugLogEntry : IDynamicJson
     {
         public long Term { get; set; }
         public long Index { get; set; }
@@ -283,7 +283,7 @@ public abstract partial class RachisConsensus
 }
 
 
-public abstract class RaftDebugView : IDynamicJsonValueConvertible
+public abstract class RaftDebugView : IDynamicJson
 {
     private readonly RachisConsensus _engine;
     public abstract string Role { get; }
@@ -310,7 +310,7 @@ public abstract class RaftDebugView : IDynamicJsonValueConvertible
         Log = _engine.GetLogDetails(context, fromIndex, take, detailed);
     }
 
-    public class PeerConnection(string destination, string status, bool connected) : IDynamicJsonValueConvertible
+    public class PeerConnection(string destination, string status, bool connected) : IDynamicJson
     {
         public bool Connected = connected;
         public string Destination = destination;
@@ -369,7 +369,7 @@ public abstract class RaftDebugView : IDynamicJsonValueConvertible
         }
     }
 
-    public class RaftCommandsVersion : IDynamicJsonValueConvertible
+    public class RaftCommandsVersion : IDynamicJson
     {
         public int Cluster;
         public int Local;
@@ -457,7 +457,7 @@ public class CandidateDebugView(Candidate candidate) : RaftDebugView(candidate.E
 }
 
 
-public class RachisDebugMessage : IDynamicJsonValueConvertible
+public class RachisDebugMessage : IDynamicJson
 {
     public DateTime At = DateTime.UtcNow;
     public string Message;

--- a/src/Raven.Server/ServerWide/ClusterTransactionResult.cs
+++ b/src/Raven.Server/ServerWide/ClusterTransactionResult.cs
@@ -1,8 +1,8 @@
-﻿using Sparrow.Json;
+using Sparrow.Json;
 using Sparrow.Json.Parsing;
 
 namespace Raven.Server.ServerWide;
-public class ClusterTransactionResult : IDynamicJsonValueConvertible
+public class ClusterTransactionResult : IDynamicJson
 {
     public DynamicJsonArray GeneratedResult { get; set; }
 

--- a/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/ClusterTransactionCommand.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -103,7 +103,7 @@ namespace Raven.Server.ServerWide.Commands
         }
         }
 
-        public sealed class ClusterTransactionErrorInfo : IDynamicJsonValueConvertible
+        public sealed class ClusterTransactionErrorInfo : IDynamicJson
         {
             public string Message;
             public ConcurrencyViolation Violation;

--- a/src/Raven.Server/ServerWide/Commands/CompareExchangeCommands.cs
+++ b/src/Raven.Server/ServerWide/Commands/CompareExchangeCommands.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -175,7 +175,7 @@ namespace Raven.Server.ServerWide.Commands
             return JsonDeserializationCluster.CompareExchangeResult(((BlittableJsonReaderObject)remoteResult).Clone(ContextToWriteResult));
         }
 
-        public sealed class CompareExchangeResult : IDynamicJsonValueConvertible
+        public sealed class CompareExchangeResult : IDynamicJson
         {
             public long Index;
             public object Value;

--- a/src/Raven.Server/ServerWide/Commands/Subscriptions/RecordBatchSubscriptionDocumentsCommand.cs
+++ b/src/Raven.Server/ServerWide/Commands/Subscriptions/RecordBatchSubscriptionDocumentsCommand.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Raven.Client.Documents.Subscriptions;
 using Raven.Client.Exceptions.Database;
@@ -369,7 +369,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
 
     }
 
-    public sealed class DocumentRecord : SubscriptionRecord, IDynamicJsonValueConvertible
+    public sealed class DocumentRecord : SubscriptionRecord, IDynamicJson
     {
         public string DocumentId;
         public string ChangeVector;
@@ -384,7 +384,7 @@ namespace Raven.Server.ServerWide.Commands.Subscriptions
         }
     }
 
-    public sealed class RevisionRecord : SubscriptionRecord, IDynamicJsonValueConvertible
+    public sealed class RevisionRecord : SubscriptionRecord, IDynamicJson
     {
         public string DocumentId;
         public string Previous;

--- a/src/Raven.Server/Utils/TypeConverter.cs
+++ b/src/Raven.Server/Utils/TypeConverter.cs
@@ -113,7 +113,7 @@ namespace Raven.Server.Utils
             if (value is byte[])
                 return true;
 
-            if (value is IDynamicJsonValueConvertible)
+            if (value is IDynamicJson)
                 return true;
 
             if (value is IEnumerable enumerable)

--- a/src/Raven.Server/Web/Studio/UpgradeInfoHandler.cs
+++ b/src/Raven.Server/Web/Studio/UpgradeInfoHandler.cs
@@ -93,7 +93,7 @@ public sealed class UpgradeInfoHandler : ServerRequestHandler
         public int ChangelogPageNumber { get; set; }
     }
     
-    public class BuildCompatibilityInfo : IDynamicJsonValueConvertible
+    public class BuildCompatibilityInfo : IDynamicJson
     {
         public string FullVersion { get; set; }
         public bool CanDowngradeFollowingUpgrade { get; set; }

--- a/src/Raven.Server/Web/System/AdminServerWideHandler.cs
+++ b/src/Raven.Server/Web/System/AdminServerWideHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -140,7 +140,7 @@ namespace Raven.Server.Web.System
             if (Enum.TryParse(typeAsString, out OngoingTaskType type) == false)
                 throw new ArgumentException($"{typeAsString} is unknown task type.");
 
-            Func<BlittableJsonReaderObject, IDynamicJsonValueConvertible> converter;
+            Func<BlittableJsonReaderObject, IDynamicJson> converter;
             switch (type)
             {
                 case OngoingTaskType.Backup:
@@ -223,7 +223,7 @@ namespace Raven.Server.Web.System
         }
 
         private async Task GetTaskConfigurationsAsync<T>(OngoingTaskType type, Func<BlittableJsonReaderObject, T> converter)
-            where T : IDynamicJsonValueConvertible
+            where T : IDynamicJson
         {
             var taskName = GetStringQueryString("name", required: false);
 
@@ -245,8 +245,8 @@ namespace Raven.Server.Web.System
         }
     }
 
-    public sealed class ServerWideTasksResult<T> : IDynamicJsonValueConvertible
-        where T : IDynamicJsonValueConvertible
+    public sealed class ServerWideTasksResult<T> : IDynamicJson
+        where T : IDynamicJson
     {
         public List<T> Results;
 

--- a/src/Sparrow/Json/IDynamicJsonValueConvertible.cs
+++ b/src/Sparrow/Json/IDynamicJsonValueConvertible.cs
@@ -1,9 +1,0 @@
-﻿using Sparrow.Json.Parsing;
-
-namespace Sparrow.Json
-{
-    public interface IDynamicJsonValueConvertible
-    {
-        DynamicJsonValue ToJson();
-    }
-}

--- a/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
+++ b/src/Sparrow/Json/Parsing/ObjectJsonParser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -622,7 +622,7 @@ namespace Sparrow.Json.Parsing
                     continue;
                 }
 
-                if (current is IDynamicJsonValueConvertible convertible)
+                if (current is IDynamicJson convertible)
                 {
                     current = convertible.ToJson();
                     continue;


### PR DESCRIPTION
## Summary
- replace implementations of IDynamicJsonValueConvertible with IDynamicJson across client and server tasks
- update parsers, converters, and generics to rely on IDynamicJson and remove the redundant interface definition

## Testing
- dotnet build RavenDB.sln *(fails: dotnet command not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916f6d29ae4833193ffba88f3ba03b4)